### PR TITLE
Add mod+d/escape

### DIFF
--- a/keymap.c
+++ b/keymap.c
@@ -22,9 +22,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 /* Keymap 0: Base Layer
  *
  * ,------------------------------------------------------.           ,-------------------------------------------------------.
- * | Escape    |  1   |  2   |  3   |   4   |   5  | !    |           |  =   |   6  |   7  |   8  |   9   |   0   |    _      |
+ * | Escape    |  1   |  2   |  3   |   4   |   5  | !    |           |  =   |   6  |   7  |   8  |   9   |   0   |  Escape   |
  * |-----------+------+------+------+-------+-------------|           |------+------+------+------+-------+-------+-----------|
- * |      /    |   Q  |   W  |   E  |   R   |   T  |      |           |      |   Y  |   U  |   I  |   O   |   P   |    ~      |
+ * |      /    |   Q  |   W  |   E  |   R   |   T  |      |           |      |   Y  |   U  |   I  |   O   |   P   |  GUI(D)   |
  * |-----------+------+------+------+-------+------|   *  |           |  +   |------+------+------+-------+-------+-----------|
  * |    Tab    |   A  |   S  |   D  |   F   |   G  |------|           |------|   H  |   J  |   K  |   L   | TO(1) |    "      |
  * |-----------+------+------+------+-------+------|      |           |      |------+------+------+-------+-------+-----------|
@@ -52,8 +52,8 @@ KC_LCTL, LSFT(KC_LGUI), LSFT(KC_LALT),  KC_LALT,   KC_LGUI,
                         KC_SPACE,   KC_BSPACE,  KC_DEL,
 
 // right hand
-KC_EQUAL,   KC_6,     KC_7,   KC_8,   KC_9,     KC_0,   KC_UNDS,
-KC_PLUS,    KC_Y,     KC_U,   KC_I,   KC_O,     KC_P,   KC_LCTL,
+KC_EQUAL,   KC_6,     KC_7,   KC_8,   KC_9,     KC_0,   KC_ESCAPE,
+KC_PLUS,    KC_Y,     KC_U,   KC_I,   KC_O,     KC_P,   LGUI(KC_D),
             KC_H,     KC_J,   KC_K,   KC_L,     TG(1),  KC_DQUO,
 KC_MINUS,   KC_N,     KC_M,   KC_DOT, KC_COMMA, TG(2),  KC_QUOTE,
 KC_ESCAPE,  KC_COLN,  KC_PERC,  KC_NO,  KC_LGUI,


### PR DESCRIPTION
Using i3 with rofi means a common combo Mod+D and escape. Adding these keys within easy reach.